### PR TITLE
feat: use native styling instead of unocss

### DIFF
--- a/src/component.tsx
+++ b/src/component.tsx
@@ -4,10 +4,7 @@ import { useScroll, useVModel } from '@vueuse/core'
 import { defineComponent, ref, toRef, watchEffect } from 'vue'
 import { useHighlight } from './composables'
 import { vueShikiInputProps } from './types'
-import 'uno.css'
 import './style.css'
-
-const commonClass = 'h-full tab-4 whitespace-pre inset-0 font-mono tracking-normal box-border!'
 
 export const VueShikiInput = defineComponent({
   props: vueShikiInputProps,
@@ -43,7 +40,7 @@ export const VueShikiInput = defineComponent({
     return () => (
       <div
         class={[
-          'overflow-hidden rounded-4px __shiki-vue-input-container grid grid-rows-[auto_1fr_auto]',
+          '__shiki-vue-input-container',
         ]}
         style={[
           props.autoBackground && background.value?.color
@@ -55,7 +52,7 @@ export const VueShikiInput = defineComponent({
       >
         <div>{ slots.header?.() }</div>
         <div
-          class={['__shiki-vue-input relative overflow-hidden', {
+          class={['__shiki-vue-input', {
             'line-numbers': props.lineNumbers,
           }]}
           style={{
@@ -66,8 +63,7 @@ export const VueShikiInput = defineComponent({
             ref={highlightContainerRef}
             innerHTML={output.value}
             class={[
-              commonClass,
-              'block absolute w-full',
+              '__shiki-vue-input-highlighted',
             ]}
             style={{
               top: `${-y.value}px`,
@@ -89,15 +85,11 @@ export const VueShikiInput = defineComponent({
                     ref={textareaRef}
                     disabled={props.disabled}
                     class={[
-                      commonClass,
-                      'absolute z-10 resize-none font-mono overflow-auto bg-transparent b-none',
-                      'outline-none text-transparent p-0',
-                      props.lineNumbers ? 'ml-2.5rem! w-[calc(100%-2.5rem)]!' : 'w-full!',
-                      [
-                        props.darkTheme || background.value?.type === 'dark'
-                          ? 'caret-white'
-                          : 'caret-black',
-                      ],
+                      '__shiki-vue-input-textarea',
+                      {
+                        'has-line-numbers': props.lineNumbers,
+                        'is-dark': props.darkTheme || background.value?.type === 'dark',
+                      },
                     ]}
                     style={{
                       padding: `${props.offset!.y}px ${props.offset!.x}px`,

--- a/src/style.css
+++ b/src/style.css
@@ -1,6 +1,58 @@
 .__shiki-vue-input-container {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  overflow: hidden;
+  border-radius: 4px;
 
   .__shiki-vue-input {
+    position: relative;
+    overflow: hidden;
+
+    .__shiki-vue-input-highlighted, .__shiki-vue-input-textarea {
+      height: 100%;
+      -moz-tab-size: 4;
+      -o-tab-size: 4;
+      tab-size: 4;
+      white-space: pre;
+      inset: 0;
+      font-family: ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,Liberation Mono,Courier New,monospace;
+      letter-spacing: 0em;
+      box-sizing: border-box !important;
+    }
+
+    .__shiki-vue-input-highlighted {
+      display: block;
+      position: absolute;
+      width: 100%;
+
+      pre {
+        margin: 0;
+      }
+    }
+
+    .__shiki-vue-input-textarea {
+      position: absolute;
+      z-index: 10;
+      resize: none;
+      overflow: auto;
+      background-color: transparent;
+      border-style: none;
+      outline-style: none;
+      color: transparent;
+      padding: 0;
+
+      width: 100% !important;
+      &.has-line-numbers {
+        margin-left: 2.5rem !important;
+        width: calc(100% - 2.5rem) !important;
+      }
+
+      caret-color: black;
+      &.is-dark {
+        caret-color: white;
+      }
+    }
+
     &.line-numbers {
       code {
         counter-reset: step;
@@ -17,41 +69,5 @@
       }
     }
   }
-
-  /* Copied from `@unocss/reset/tailwind.css` */
-
-  *,
-  ::before,
-  ::after {
-    box-sizing: border-box;
-    border-width: 0;
-    border-style: solid;
-  }
-
-  code, pre {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; 1,
-    font-feature-settings: normal;
-    font-variation-settings: normal;
-    font-size: 1em;
-  }
-
-  code {
-    cursor: text !important;
-  }
-
-  pre {
-    margin: 0;
-  }
-
-  textarea {
-    font-feature-settings: inherit;
-    font-variation-settings: inherit;
-    font-size: 100%;
-    font-weight: inherit;
-    line-height: inherit;
-    margin: 0;
-    padding: 0;
-  }
-
 }
 


### PR DESCRIPTION
Closes #75. Moves all the styling into style.css and removes all UnoCSS classnames in the component itself. Also removes the reset since in testing I don't believe it did much, anything that seemed to have an effect was moved to the styles above. The preview on the docs website looks the exact same in my testing despite these changes :)