### PR TITLE
fix: style.css does not exist, use index.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pnpm i vue-shiki-input
 <script setup lang="ts">
 import { ref } from 'vue'
 import { VueShikiInput } from 'vue-shiki-input'
-import 'vue-shiki-input/style.css'
+import 'vue-shiki-input/index.css'
 
 const text = ref('const a = 1;')
 </script>

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ pnpm install vue-shiki-input
 <script setup lang="ts">
 import { ref } from 'vue'
 import { VueShikiInput } from 'vue-shiki-input'
-import 'vue-shiki-input/style.css'
+import 'vue-shiki-input/index.css'
 
 const text = ref('const a = 1;')
 </script>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
-    "./style.css": "./dist/style.css"
+    "./index.css": "./dist/index.css"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
The build pipeline currently does not output a file called `dist/style.css`, as suggested by the documentation. Rather, this file (`src/style.css`) is compiled to `dist/index.css`. I don't know how to work Vite to make the output file match the input file name, but this is another solution to just update the documentation and exports paths in package.json to match what is actually being published.